### PR TITLE
Symlink to /sbin/udevadm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,8 +102,8 @@ jobs:
       language: bash
       script: ./server/run_coinboot
 
-      #- <<: *run_coinboot
-      #  env: KERNEL=5.3.0-29-generic SUITE=eoan
+      - <<: *run_coinboot
+        env: KERNEL=5.3.0-29-generic SUITE=eoan
 
     - stage: release
       if: branch = master

--- a/debirf/profiles/coinboot/modules/y0_network
+++ b/debirf/profiles/coinboot/modules/y0_network
@@ -32,6 +32,13 @@ auto lo
 iface lo inet loopback
 
 # A default dynamic ethernet address.
+
 allow-hotplug eth0
 iface eth0 inet dhcp
 EOF
+
+# Since focal udevadm is under /bin so lets
+# create a symlink to not break our init script.
+if [[ -f "${DEBIRF_ROOT}"/sbin/udevadm ]]; then
+  debirf_exec ln -s /bin/udevadm /sbin/udevadm
+fi


### PR DESCRIPTION
Since **focal** `udevadm` is under `/bin/` so we have to create a symlink from `/sbin/udevadm` to `/bin/udevadm`.